### PR TITLE
Fix ignore files

### DIFF
--- a/src/Commands/GenerateClient.php
+++ b/src/Commands/GenerateClient.php
@@ -156,6 +156,10 @@ abstract class GenerateClient extends Command
             return true;
         }
 
+        if ($level === 0 && !is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
         $disableDeleteDir = false;
         foreach (scandir($dir) as $fileWithoutDir) {
             if (in_array($fileWithoutDir, ['..', '.'])) {

--- a/src/Commands/GenerateClient.php
+++ b/src/Commands/GenerateClient.php
@@ -150,35 +150,36 @@ abstract class GenerateClient extends Command
         return $resultPath;
     }
 
-    private function recursiveClearDirectory(string $dir, int $level = 0)
+    private function recursiveClearDirectory(string $dir, int $level = 0, string $baseDir = ''): bool
     {
         if (!$dir) {
-            return;
+            return true;
         }
 
-        if ($level === 0 && !is_dir($dir)) {
-            mkdir($dir, 0755, true);
-        }
-
+        $disableDeleteDir = false;
         foreach (scandir($dir) as $fileWithoutDir) {
             if (in_array($fileWithoutDir, ['..', '.'])) {
                 continue;
             }
             $file = $dir . "/" . $fileWithoutDir;
+            $pathFromBase = $baseDir ? $baseDir . '/' . $fileWithoutDir : $fileWithoutDir;
 
-            if ($level === 0 && in_array($fileWithoutDir, $this->filesToIgnoreDuringCleanup)) {
+            if (in_array($pathFromBase, $this->filesToIgnoreDuringCleanup)) {
+                $disableDeleteDir = true;
                 continue;
             }
 
             if (is_dir($file)) {
-                $this->recursiveClearDirectory($file, $level + 1);
+                $disableDeleteDir = $this->recursiveClearDirectory($file, $level + 1, $pathFromBase) || $disableDeleteDir;
             } else {
                 unlink($file);
             }
         }
 
-        if ($level > 0) {
+        if ($level > 0 && !$disableDeleteDir) {
             rmdir($dir);
         }
+
+        return $disableDeleteDir;
     }
 }

--- a/src/Commands/GenerateClient.php
+++ b/src/Commands/GenerateClient.php
@@ -166,6 +166,7 @@ abstract class GenerateClient extends Command
 
             if (in_array($pathFromBase, $this->filesToIgnoreDuringCleanup)) {
                 $disableDeleteDir = true;
+
                 continue;
             }
 

--- a/src/Commands/GeneratePhpClient.php
+++ b/src/Commands/GeneratePhpClient.php
@@ -76,7 +76,18 @@ class GeneratePhpClient extends GenerateClient
             RegexIterator::MATCH
         );
 
+        $filesOrFoldersToIgnore = array_map(
+            fn ($fileOfFolder) => $this->outputDir . '/' . $fileOfFolder,
+            $this->filesToIgnoreDuringCleanup
+        );
+
         foreach ($files as $file) {
+            foreach ($filesOrFoldersToIgnore as $fileOrFolderToIgnore) {
+                if (str_contains($file, $fileOrFolderToIgnore)) {
+                    continue 2;
+                }
+            }
+
             try {
                 $patcher = new PhpEnumPatcher($file);
                 $patcher->patch();


### PR DESCRIPTION
Выдернул из https://github.com/ensi-platform/laravel-openapi-client-generator/pull/1/files#diff-a3459fcbd854e0a7ff7651a3b089468582fd325a63438f9fda09be47ebbe21f4 код необходимый для игнорирования файлов не из корня клиента.

Также пришлось поправить патчер для енамов, без доработок он лезет во все енамы, а в моей задачке нужно как раз создать кастомный енам, который не нужно патчить.

По поводу тестов я так понял, что их толком нет, только общий тест об успешном выполнении команды генерации клиента.

Правок шаблона не требуется, обратная совместимость с ним не нарушается.

PS: в твоём мр ты выпилила кусочек https://github.com/ensi-platform/laravel-openapi-client-generator/blob/master/src/Commands/GenerateClient.php#L159
Без него не проходят тесты, ну и если не будет папки под клиент, то руками её нужно будет создавать.
Вернул обратно.

PSPS: в текущем МР часть тестов не проходит, что-то не то с версиями JVM, у меня и на локалке также и я посмотрел соседний МР Андрея, там тоже так. Имхо это не баг кода, имхо нужно отдельно с этим разбираться.