### PR TITLE
fix: merge config "openapi-client-generator.php.apidoc_dir" -> "openapi-client-generator.apidoc_dir"

### DIFF
--- a/src/OpenapiClientGeneratorServiceProvider.php
+++ b/src/OpenapiClientGeneratorServiceProvider.php
@@ -13,7 +13,7 @@ class OpenapiClientGeneratorServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(
             __DIR__ . '/../config/' . self::CONFIG_FILE_NAME,
-            self::CONFIG_FILE_NAME
+            str_replace('.php', '', self::CONFIG_FILE_NAME)
         );
     }
 


### PR DESCRIPTION
Исправлена ошибка:

Cannot assign null to property Ensi\LaravelOpenapiClientGenerator\Commands\GenerateClient::$apiDocDir of type string

Шаги воспроизведения:

1. Установить пакет через composer require
2. Проверить отсутствие openapi-client-generator.php в папке config внутри проекта
3. Запустить любую команду через php artisan

Примечание:

Ошибка из-за того, что в конструкторе `GenerateClient` пытается not-nullable присвоить null значение, потому что в ServiceProvider допущена ошибка в mergeConfig.

Т.е. путь будет `openapi-client-generator.php.apidoc_dir`